### PR TITLE
Add a test for tokio::time::sleep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +37,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cfg-if"
@@ -49,6 +61,16 @@ name = "libc"
 version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "memchr"
@@ -72,6 +94,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
 ]
 
 [[package]]
@@ -105,10 +150,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "stats_alloc"
@@ -121,6 +187,7 @@ name = "stats_alloc_helper"
 version = "0.3.1"
 dependencies = [
  "libc",
+ "parking_lot",
  "probe",
  "stats_alloc",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ tokio = { version = "1", features = ["rt", "macros", "time"], optional = true }
 libc = { version = "0.2" }
 probe = { version = "0.5" }
 
+[dev-dependencies]
+parking_lot = { version = "0.12" }
+
 [features]
 default = []
 async_tokio = ["tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["alloc", "stats_alloc", "benchmark"]
 
 [dependencies]
 stats_alloc = { version = "0.1" }
-tokio = { version = "1", features = ["rt", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "macros", "time"], optional = true }
 libc = { version = "0.2" }
 probe = { version = "0.5" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,4 +354,43 @@ mod tests {
             }
         );
     }
+
+    #[tokio::test]
+    #[cfg(feature = "async_tokio")]
+    async fn test_tokio_sleep() {
+        let duration = std::time::Duration::from_millis(1000);
+
+        let stats = memory_measured_future(&GLOBAL, async move {
+            tokio::time::sleep(duration).await;
+        })
+        .await;
+
+        // Empirically measured, subject to change
+
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            stats,
+            Stats {
+                allocations: 3,
+                deallocations: 0,
+                reallocations: 0,
+                bytes_allocated: 176,
+                bytes_deallocated: 0,
+                bytes_reallocated: 0
+            }
+        );
+
+        #[cfg(target_os = "linux")]
+        assert_eq!(
+            stats,
+            Stats {
+                allocations: 0,
+                deallocations: 0,
+                reallocations: 0,
+                bytes_allocated: 0,
+                bytes_deallocated: 0,
+                bytes_reallocated: 0
+            }
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mutex() {
+    fn test_std_mutex() {
         let lock = Arc::new(Mutex::new(()));
 
         let stats = memory_measured(&GLOBAL, || {
@@ -359,6 +359,27 @@ mod tests {
         );
 
         #[cfg(target_os = "linux")]
+        assert_eq!(
+            stats,
+            Stats {
+                allocations: 0,
+                deallocations: 0,
+                reallocations: 0,
+                bytes_allocated: 0,
+                bytes_deallocated: 0,
+                bytes_reallocated: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_parking_lot_mutex() {
+        let lock = Arc::new(parking_lot::Mutex::new(()));
+
+        let stats = memory_measured(&GLOBAL, || {
+            drop(lock.lock());
+        });
+
         assert_eq!(
             stats,
             Stats {


### PR DESCRIPTION
The interesting bit about it is that it's differrent between Linux and macOS.

I can't trace on my macOS, but I can panic in the allocator, so here's the first allocation that happens under macOS:

```
  15:        0x10214d2d0 - <stats_alloc_helper::LockedAllocator<T> as core::alloc::global::GlobalAlloc>::alloc::{{closure}}::he1697777c82db353
                               at /Users/ivan/projects/stats_alloc_helper/src/lib.rs:152:17
  16:        0x10214ce98 - stats_alloc_helper::LockedAllocator<T>::serialized::h8faa8ca04b8e434f
                               at /Users/ivan/projects/stats_alloc_helper/src/lib.rs:100:22
  17:        0x10214d244 - <stats_alloc_helper::LockedAllocator<T> as core::alloc::global::GlobalAlloc>::alloc::h399cd4b35d085c28
                               at /Users/ivan/projects/stats_alloc_helper/src/lib.rs:149:9
  18:        0x102144624 - __rust_alloc
                               at /Users/ivan/projects/stats_alloc_helper/src/lib.rs:247:20
  19:        0x1022060f0 - alloc::alloc::alloc::h75c195176cfe8a36
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/alloc/src/alloc.rs:100:9
  20:        0x1022060f0 - alloc::alloc::Global::alloc_impl::hbd7cdcabd8d325ea
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/alloc/src/alloc.rs:183:73
  21:        0x1022060f0 - <alloc::alloc::Global as core::alloc::Allocator>::allocate::hb2f142bb174a2302
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/alloc/src/alloc.rs:243:9
  22:        0x1022060f0 - alloc::alloc::exchange_malloc::hca959d25e82ecfdd
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/alloc/src/alloc.rs:332:18
  23:        0x1022060f0 - alloc::boxed::Box<T>::new::h58807f1c0788cece
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/alloc/src/boxed.rs:260:9
  24:        0x1022060f0 - <std::sys::sync::mutex::pthread::AllocatedMutex as std::sys_common::lazy_box::LazyInit>::init::h8f3071639a33e15f
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/sync/mutex/pthread.rs:23:21
  25:        0x102221a24 - std::sys_common::lazy_box::LazyBox<T>::initialize::hedebe0e060d690eb
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys_common/lazy_box.rs:55:37
  26:        0x1021b483c - std::sys_common::lazy_box::LazyBox<T>::get_pointer::h9f5412604728f16c
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys_common/lazy_box.rs:50:28
  27:        0x1021b483c - <std::sys_common::lazy_box::LazyBox<T> as core::ops::deref::Deref>::deref::h9bb67be1bb24e645
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys_common/lazy_box.rs:72:25
  28:        0x1021b483c - std::sys::sync::mutex::pthread::raw::ha13738f6b32bb2ec
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/sync/mutex/pthread.rs:15:5
  29:        0x1021c15f8 - std::sys::sync::mutex::pthread::Mutex::lock::h2670ec0ed30af42a
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/sync/mutex/pthread.rs:114:42
  30:        0x1021c15f8 - std::sync::mutex::Mutex<T>::lock::ha543ca5d19942f4a
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sync/mutex.rs:317:24
  31:        0x1021c8eec - tokio::loom::std::mutex::Mutex<T>::lock::h46c24d42c9c6e381
                               at /Users/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/loom/std/mutex.rs:22:15
  32:        0x1021b38a0 - tokio::runtime::time::ShardedWheel::lock_sharded_wheel::hb62d260e17127893
                               at /Users/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/time/mod.rs:508:9
  33:        0x1021d2c80 - tokio::runtime::time::<impl tokio::runtime::time::handle::Handle>::reregister::hdd6f8c82523129ce
                               at /Users/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/time/mod.rs:421:28
  34:        0x1021d20a0 - tokio::runtime::time::entry::TimerEntry::reset::ha6bb9d24774fbf66
                               at /Users/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/time/entry.rs:558:17
  35:        0x1021d2154 - tokio::runtime::time::entry::TimerEntry::poll_elapsed::h958bb0e05f02a025
                               at /Users/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/time/entry.rs:576:13
  36:        0x1021b0900 - tokio::time::sleep::Sleep::poll_elapsed::h00b0bdff39f97821
                               at /Users/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/time/sleep.rs:416:22
  37:        0x1021b0a34 - <tokio::time::sleep::Sleep as core::future::future::Future>::poll::h8200f0e7eef79a6e
                               at /Users/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/time/sleep.rs:448:22
  38:        0x10215dd5c - stats_alloc_helper::tests::test_tokio_sleep::{{closure}}::{{closure}}::h72431f4fdd9f30bd
                               at /Users/ivan/projects/stats_alloc_helper/src/lib.rs:366:42
```

I don't know if it's this or something else:

* https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html#thinner-faster-mutexes-on-linux

I was developing this whole thing on macOS and I needed to roll my own locking just because standard library `Mutex` locking was allocating.